### PR TITLE
Allow native textarea resizing

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -882,7 +882,7 @@
     savable:false,
     width: 'inherit',
     height: 'inherit',
-    resize: 'none',
+    resize: 'default',
     iconlibrary: 'glyph',
     language: 'en',
     initialstate: 'editor',


### PR DESCRIPTION
I use this with the bootstrap theme and it's too small by default and too large in expanded view. This allows the browser's native textarea resizing to function.